### PR TITLE
Un-track show, first phase

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -44,6 +44,10 @@
     background:#fff;
     padding:6px 0px 6px 11px;
     box-shadow:2px 2px 4px #bebebe;
+    -webkit-transition: all 1.5s ease;
+    -moz-transition: all 1.5s ease;
+    -o-transition: all 1.5s ease;
+    transition: all 1.5s ease;
 }
 .notification {
     padding:1.5rem 1.5rem 1.5rem 1.5rem;
@@ -128,6 +132,13 @@
     .tv-result img.tv-background {
         top: 0px;
     }
+}
+#side_track_undefined {
+    display:none; /* CSS hack */
+}
+.remove_track {
+    background: rgba(172, 36, 36, 0.95);
+    color: #fff;
 }
 .new_track {
     background: rgba(81, 171, 84, 0.95);

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -43,7 +43,7 @@
 .side_show_list {
     background:#fff;
     padding:6px 0px 6px 11px;
-    box-shadow:2px 2px 4px #bebebe;
+    box-shadow: 0 0.5em 1em -0.125em rgba(10,10,10,.1), 0 0 0 1px rgba(10,10,10,.02);
     -webkit-transition: all 1.5s ease;
     -moz-transition: all 1.5s ease;
     -o-transition: all 1.5s ease;
@@ -56,6 +56,12 @@
 .footer {
     background:#e8e8e840;
     padding: 2rem 1.5rem 2rem;
+}
+#tracking_side {
+    background-color:none;
+    border-radius: 4px;
+    padding: 0;
+    position: relative;
 }
 .tracking_title {
     margin-bottom:12px;
@@ -152,4 +158,14 @@
 }
 .notification a:not(.button):not(.dropdown-item):hover{
     text-decoration:underline;
+}
+#youtube_embed {
+    margin-bottom:20px;
+}
+#youtube_description {
+    overflow:auto;
+    font-size: 0.9rem;
+}
+#youtube_wrapper {
+    display:none;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -281,7 +281,7 @@ function renderTV(searchQuery){
         url: 'https://www.googleapis.com/youtube/v3/search',
         data: {
             key:'AIzaSyBR9R0HWwxFiBHqI4lXjjDhajBe4Idl6wE',
-            q: searchQuery,
+            q: searchQuery+' ('+showYear+')',
             part: 'snippet',
             maxResults: 1,
             type: 'video',

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -28,9 +28,10 @@ var fanartAPISearch
 var bgImage
 var storeFetch = localStorage.getItem('TVtracker')
 storeFetch = JSON.parse(storeFetch)
-if (!storeFetch){
+if (!storeFetch || jQuery.isEmptyObject(storeFetch[0]) ){
   storeFetch = []
 }
+
 function add(array, transferID, transferTitle) {
   const { length } = array;
   const found = array.some(el => el.title === transferTitle);
@@ -182,11 +183,53 @@ function renderTV(searchQuery){
       } else {
         $('#result-'+val.show.id).append('<div class="show-add" data-id="'+val.show.id+'" data-title="'+ showTitle +'"><span class="icon icon-save"></span></div>')
       }
-      $('#result-'+val.show.id+' div span').click(function(){
+      $('#result-'+val.show.id+' div span.icon-remove').click(function(){
         storeID = $('#result-'+val.show.id+' .show-add').data("id")
         storeTitle = $('#result-'+val.show.id+' .show-add').data("title")
+        $(this).toggleClass("icon-save")
+        $(this).toggleClass("icon-remove")
+        //$("#tracking_side").append('<div class="side_show_list" data-side-id="side_'+storeID+'"><i class="icon icon-remove sidebar_show_remove"></i><span class="sidebar_show_span"><a class="sidebar_show_link" href="#'+storeTitle+'">'+storeTitle+'</a></span></div>')
+        //$('[data-side-id="side_'+val.show.id+'"]').toggleClass('remove_track', 300).toggleClass('new_track', 300)
+        $('[data-side-id="side_'+val.show.id+'"]').removeClass('new_track')
+        $('[data-side-id="side_'+val.show.id+'"]').addClass('remove_track')
+        setTimeout(function(){
+          $('[data-side-id="side_'+val.show.id+'"]').fadeOut( "slow", function() {
+            $('[data-side-id="side_'+val.show.id+'"]').remove()
+          });
+        }, 1000)
+        //$('[data-side-id="side_'+val.show.id+'"]').toggle("highlight")
+        var found = {}
+        $('[data-side-id]').each(function(){
+          var $this = $(this)
+          if(found[$this.data('side-id')]){
+            $this.remove()
+          }
+          else{
+            found[$this.data('side-id')] = true;   
+          }
+        })
+        var trimArray = storeFetch.filter(function(obj) {
+          return obj.id !== val.show.id
+        })
+        storeFetch = add(trimArray, storeID, storeTitle) // Function to prevent duplicate entries
+        localStorage.setItem('TVtracker', JSON.stringify(storeFetch))
+      })
+      $('#result-'+val.show.id+' div span.icon-save').click(function(){
+        storeID = $('#result-'+val.show.id+' .show-add').data("id")
+        storeTitle = $('#result-'+val.show.id+' .show-add').data("title")
+        $(this).toggleClass("icon-save")
+        $(this).toggleClass("icon-remove")
         $("#tracking_side").append('<div class="side_show_list" data-side-id="side_'+storeID+'"><i class="icon icon-remove sidebar_show_remove"></i><span class="sidebar_show_span"><a class="sidebar_show_link" href="#'+storeTitle+'">'+storeTitle+'</a></span></div>')
-        $('[data-side-id="side_'+val.show.id+'"]').addClass('new_track')
+        //$('[data-side-id="side_'+val.show.id+'"]').toggleClass('new_track', 300).toggleClass('remove_track', 300)
+        //$('[data-side-id="side_'+val.show.id+'"]').toggleClass('remove_track', 500).toggleClass('new_track', 500)
+        $('[data-side-id="side_'+val.show.id+'"]').removeClass('remove_track')
+        $('[data-side-id="side_'+val.show.id+'"]').fadeIn( "slow", function() {
+          $('[data-side-id="side_'+val.show.id+'"]').addClass('new_track')
+        })
+        setTimeout(function(){
+          $('[data-side-id="side_'+val.show.id+'"]').removeClass('new_track')
+        }, 1500)
+        //$('[data-side-id="side_'+val.show.id+'"]').toggle("highlight")
         // Check if the sidebar item already exists
         var found = {}
         $('[data-side-id]').each(function(){
@@ -198,9 +241,11 @@ function renderTV(searchQuery){
             found[$this.data('side-id')] = true;   
           }
         })
-        storeFetch = add(storeFetch, storeID, storeTitle) // Function to prevent duplicate entries
+        var trimArray = storeFetch.filter(function(obj) {
+          return obj.id !== val.show.id
+        })
+        storeFetch = add(trimArray, storeID, storeTitle) // Function to prevent duplicate entries
         localStorage.setItem('TVtracker', JSON.stringify(storeFetch))
-        //console.log(storeFetch) // localStorage Array w/ Objects
       })
       $('#column-'+val.show.id).append('<div class="column" id="column-right-'+val.show.id+'">')
       if (showStatus){

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -31,12 +31,16 @@ storeFetch = JSON.parse(storeFetch)
 if (!storeFetch || jQuery.isEmptyObject(storeFetch[0]) ){
   storeFetch = []
 }
-
 function add(array, transferID, transferTitle) {
   const { length } = array;
   const found = array.some(el => el.title === transferTitle);
   if (!found) array.push({ id: transferID, title: transferTitle });
   return array;
+}
+function decodeHtml(str){
+  var txt = document.createElement("textarea");
+  txt.innerHTML = str;
+  return txt.value;
 }
 function renderSchedule(){
   var i;
@@ -271,7 +275,6 @@ function renderTV(searchQuery){
           //console.log('No imdb rating')
         }
       })
-
       function getVideo() {
       $.ajax({
         type: 'GET',
@@ -289,17 +292,15 @@ function renderTV(searchQuery){
         },
       });
     }
-
-function embedVideo(data) {
-    $('iframe').attr('src', 'https://www.youtube.com/embed/' + data.items[0].id.videoId)
-    $('h3').text(data.items[0].snippet.title)
-    $('.description').text(data.items[0].snippet.description)
-}
-
-getVideo();
-      
-
-
+    function embedVideo(data) {
+      console.log(data.items)
+      $('#youtube_wrapper').show()
+      $('#youtube_embed .card-image iframe').attr('src', 'https://www.youtube.com/embed/' + data.items[0].id.videoId)
+      var shortYtitle = decodeHtml(jQuery.trim(data.items[0].snippet.title)+ "...").substring(0, 31).split(" ").slice(0, -1).join(" ")
+      $('h2.youtube_title').text(shortYtitle)
+      $('#youtube_description').text(data.items[0].snippet.description)
+    }
+    getVideo()
       fanartAPISearch = 'https://webservice.fanart.tv/v3/tv/'+showTvdb+'?api_key='+fanartAPI
       $.ajax({
         type: 'GET',

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 						</div>
 						<div id="tvColumn"></div>
 					</div>
-					<div class="column is-one-third notification">
+					<div class="column is-one-third">
 						<div id="youtube_wrapper">
 							<h2 class="is-size-4 tracking_title youtube_title"></h2>
 							<div class="card" id="youtube_embed">

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
 		</footer>
 	</body>
 	<script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+	<script src='http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.5/jquery-ui.min.js'></script>
 	<script src="https://use.fontawesome.com/releases/v5.3.1/js/all.js"></script>
 	<script src="./assets/js/script.js"></script>
 </html>

--- a/index.html
+++ b/index.html
@@ -28,12 +28,21 @@
 						</div>
 						<div id="tvColumn"></div>
 					</div>
-					<div class= "tracking_side notification">
-							<iframe src="" width=" 400px" height="275px"></iframe>
-							<h3></h3>
-							<p class="description"><p>
-						<h2 class="is-size-4 tracking_title"> Tracking </h2>
-					<div class="notification" id="tracking_side"></div>
+					<div class="column is-one-third notification">
+						<div id="youtube_wrapper">
+							<h2 class="is-size-4 tracking_title youtube_title"></h2>
+							<div class="card" id="youtube_embed">
+								<div class="card-image">
+									<iframe src="" width="100%" height="250px"></iframe>
+								</div>
+								<div class="card-content">
+									<p id="youtube_description"><p>
+								</div>
+							</div>
+						</div>
+						<h2 class="is-size-4 tracking_title">Tracking</h2>
+						<div class="notification" id="tracking_side"></div>
+					</div>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
You can remove tracked shows from the results area. This needs work because once you track or un-track a show the click does not function again until you reload the page. The next steps are to make that functional, followed by making the sidebar list star icons clickable to remove tracked shows.

I've also updated the Youtube embed styling. I also made it so that it only displays when a request is being made, that way there isn't a blank space on the page when a video hasn't been inserted. 

